### PR TITLE
Update Courses.php

### DIFF
--- a/modules/schoolsetup/Courses.php
+++ b/modules/schoolsetup/Courses.php
@@ -1632,11 +1632,11 @@ if (clean_param($_REQUEST['modfunc'], PARAM_ALPHAMOD) == 'delete' && AllowEdit()
 
 
 if ($_REQUEST['modfunc'] == 'detail') {
-    if ($_POST['button'] == 'Save' && $_REQUEST['mode'] == 'add') {
+    if ($_POST['button'] == _save && $_REQUEST['mode'] == 'add') {
         $conflict = VerifyBlockedSchedule($_REQUEST['values'], $_REQUEST['course_period_id'], 'cpv');
         $_SESSION['block_schedule_err'] = $conflict;
     }
-    if ($_POST['button'] == 'Save' && $_REQUEST['mode'] == 'edit') {
+    if ($_POST['button'] == _save && $_REQUEST['mode'] == 'edit') {
         //print_r($_REQUEST);
         $title_val = DBGet(DBQuery("SELECT PERIOD_ID,ROOM_ID FROM course_period_var WHERE course_period_id='" . $_REQUEST['course_period_id'] . "'"));
 
@@ -1653,7 +1653,7 @@ if ($_REQUEST['modfunc'] == 'detail') {
         $_SESSION['block_schedule_err'] = $conflict;
     }
 
-    if ($_POST['button'] == 'Save' && $conflict === true) {
+    if ($_POST['button'] == _save && $conflict === true) {
 
         if ($_REQUEST['mode'] == 'add') {
             $chek_assoc = DBGet(DBQuery('SELECT COUNT(*) as REC_EX FROM schedule WHERE COURSE_PERIOD_ID=' . $_REQUEST['course_period_id'] . ' AND (START_DATE<=\'' . date('Y-m-d') . '\' AND (END_DATE IS NULL OR END_DATE=\'0000-00-00\' OR END_DATE>=\'' . date('Y-m-d') . '\' ))'));


### PR DESCRIPTION
Hi everyone,

I'm proposing a change to the codebase to replace all instances of ' 'save'  with  _save ' This change is necessary to avoid errors in translation.

Currently, the translations for many languages, including Spanish, contain errors. This is because the translation strings are not properly formatted. By replacing ' 'save'  with  _save ' we can ensure that the translation strings are properly formatted and that the translations are accurate.

I have already created a new Spanish translation called "Spanish Venezuela" that is correctly translated and does not contain any errors. However, this translation has not yet been accepted.

In addition to the change to "'save'", there are several other documents where the same change needs to be made. I have listed these documents below:

Document 1: TransferredOutModal.php
Document 2: URL systempreference.php

I would appreciate it if you could review these changes and let me know if you have any questions.

Thank you,