### PR TITLE
Update SystemPreference.php

### DIFF
--- a/modules/schoolsetup/SystemPreference.php
+++ b/modules/schoolsetup/SystemPreference.php
@@ -61,7 +61,7 @@ echo '</div>';
 echo '<div class="col-md-8">';
 
 if (clean_param($_REQUEST['page_display'], PARAM_ALPHAMOD) == 'SystemPreference') {
-    if ((clean_param($_REQUEST['action'], PARAM_ALPHAMOD) == 'update') && (clean_param($_REQUEST['button'], PARAM_ALPHAMOD) == 'Save') && clean_param($_REQUEST['values'], PARAM_NOTAGS) && $_POST['values'] && User('PROFILE') == 'admin') {
+    if ((clean_param($_REQUEST['action'], PARAM_ALPHAMOD) == 'update') && (clean_param($_REQUEST['button'], PARAM_ALPHAMOD) == _Save) && clean_param($_REQUEST['values'], PARAM_NOTAGS) && $_POST['values'] && User('PROFILE') == 'admin') {
 
         $sql = 'UPDATE system_preference SET ';
         foreach ($_REQUEST['values'] as $column => $value) {
@@ -74,7 +74,7 @@ if (clean_param($_REQUEST['page_display'], PARAM_ALPHAMOD) == 'SystemPreference'
         }
         $sql = substr($sql, 0, -1) . ' WHERE SCHOOL_ID=\'' . UserSchool() . '\'';
         DBQuery($sql);
-    } elseif ((clean_param($_REQUEST['action'], PARAM_ALPHAMOD) == 'insert') && (clean_param($_REQUEST['button'], PARAM_ALPHAMOD) == 'Save') && clean_param($_REQUEST['values'], PARAM_NOTAGS) && $_POST['values'] && User('PROFILE') == 'admin') {
+    } elseif ((clean_param($_REQUEST['action'], PARAM_ALPHAMOD) == 'insert') && (clean_param($_REQUEST['button'], PARAM_ALPHAMOD) == _Save) && clean_param($_REQUEST['values'], PARAM_NOTAGS) && $_POST['values'] && User('PROFILE') == 'admin') {
 
         $sql = 'INSERT INTO system_preference SET ';
         foreach ($_REQUEST['values'] as $column => $value) {


### PR DESCRIPTION
 **Propose changes to GitHub:**

**File: systempreference.php**

**Lines: 64 and 77**

**Original code (lines 64 and 77):**

```php
if ((clean_param($_REQUEST['action'], PARAM_ALPHAMOD) == 'update') && (clean_param($_REQUEST['button'], PARAM_ALPHAMOD) == 'save') && clean_param($_REQUEST['values'], PARAM_NOTAGS) && $_POST['values'] && User('PROFILE') == 'admin') {

...

} elseif ((clean_param($_REQUEST['action'], PARAM_ALPHAMOD) == 'insert') && (clean_param($_REQUEST['button'], PARAM_ALPHAMOD) == 'save') && clean_param($_REQUEST['values'], PARAM_NOTAGS) && $_POST['values'] && User('PROFILE') == 'admin') {
```

**Proposed change (lines 64 and 77):**

```php
if ((clean_param($_REQUEST['action'], PARAM_ALPHAMOD) == 'update') && (clean_param($_REQUEST['button'], PARAM_ALPHAMOD) == _save) && clean_param($_REQUEST['values'], PARAM_NOTAGS) && $_POST['values'] && User('PROFILE') == 'admin') {

...

} elseif ((clean_param($_REQUEST['action'], PARAM_ALPHAMOD) == 'insert') && (clean_param($_REQUEST['button'], PARAM_ALPHAMOD) == _save) && clean_param($_REQUEST['values'], PARAM_NOTAGS) && $_POST['values'] && User('PROFILE') == 'admin') {
```

**Explanation:**

- The original code compares the `$_REQUEST['button']` variable with the string "save" (case-sensitive).
- The proposed change replaces the comparison with `_save` (likely a translation string).
- This ensures compatibility with different languages and translation systems.

**Reason for change:**

- To avoid translation errors and potential issues in non-English environments.
- To maintain consistency with other parts of the codebase that use translation strings.

**Additional notes:**

- These changes are aligned with the previous proposal for "'save'" to "_save" replacements.
- It's essential to thoroughly review the codebase for similar instances where translation strings might be required.