### PR TITLE
Fix: Prevent encrypted password exposure in Staff password field

### DIFF
--- a/modules/users/includes/SchoolsInfoInc.php
+++ b/modules/users/includes/SchoolsInfoInc.php
@@ -821,7 +821,7 @@ if (!$_REQUEST['modfunc']) {
 
                 echo '<span id="ajax_output_st"></span>';
             } else {
-                echo TextInputModHidden(array($this_school_mod['PASSWORD'], str_repeat('*', strlen($this_school_mod['PASSWORD']))), 'staff_school[PASSWORD]', '', 'size=20 maxlength=100 AUTOCOMPLETE = off onkeyup=passwordStrength(this.value);validate_password(this.value);');
+                echo TextInputModHidden(str_repeat('*', strlen($this_school_mod['PASSWORD'])), 'staff_school[PASSWORD]', '', 'size=20 maxlength=100 AUTOCOMPLETE = off onkeyup=passwordStrength(this.value);validate_password(this.value);');
             }
             echo "<span id='passwordStrength'></span></div></div>";
             echo '</div>'; //.col-lg-6


### PR DESCRIPTION
## Issue
When clicking on the password field in Staff Official Information 
(`/Ajax.php?modname=users/Staff.php&include=SchoolsInfoInc&custom=staff&category_id=3&ajax=true`), 
the encrypted password hash is displayed in the input field.

Example of exposed hash: `$2y$10$UXmvEh9RAUK/jZ2e4vbH0.sBcqWWm3rBHsUmGm.aAcQS.cDEg9r0q`

## Root Cause
Line 824 in `modules/users/includes/SchoolsInfoInc.php` was passing an array with the 
encrypted password as the first element to `TextInputModHidden()` function.

## Solution
Changed the password field to only pass the masked asterisks (similar to Student module 
implementation), preventing the encrypted hash from being exposed in the UI.

## Changes
- **File**: `modules/users/includes/SchoolsInfoInc.php`
- **Line**: 824
- **Before**: `TextInputModHidden(array($this_school_mod['PASSWORD'], str_repeat('*', strlen($this_school_mod['PASSWORD']))), ...)`
- **After**: `TextInputModHidden(str_repeat('*', strlen($this_school_mod['PASSWORD'])), ...)`

## Testing
- [x] Verified password field displays asterisks on click
- [x] Verified password updates still function correctly
- [x] Behavior now matches Student module password field

## Security Impact
This fixes a potential security issue where password hashes could be exposed in the UI.